### PR TITLE
Fixes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,10 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Clippy Debug
-      run: cargo clippy -V
-    - name: Clippy
-      run: cargo clippy -- -D warnings -W clippy::pedantic
-    - name: Check formatting
-      run: cargo fmt --all --check
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v3
+      - name: Clippy Debug
+        run: cargo clippy -V
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: Check formatting
+        run: cargo fmt --all --check
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 authors = ["Bennet Hattesen <bennet.hattesen@haw-hamburg.de>"]
+categories = ["encoding"]
 edition = "2024"
 description = "Slipmux de- and encoding"
 homepage = "https://github.com/teufelchen1/slipmux"
+keywords = ["slip", "serial", "uart", "framing", "coap"]
+
 license = "MIT OR Apache-2.0"
 name = "slipmux"
 readme = "README.md"
@@ -10,10 +13,12 @@ repository = "https://github.com/teufelchen1/slipmux"
 version = "0.1.0"
 
 [lints.rust]
+missing_docs = "warn"
 unsafe_code = "forbid"
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 nursery = { level = "warn", priority = -1 }
+cargo_common_metadata = "warn"
 let_underscore_untyped = "warn"
 str_to_string = "warn"
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+avoid-breaking-exported-api = false


### PR DESCRIPTION
When checking it locally I found more warnings than the CI showed. The tests are currently not checked by the CI but are usually locally with rust-analyzer and similar. The lints specified in the `Cargo.toml` are for all targets so they should be checked on CI for all targets too.

While at it, I fixed some lint warnings and added new ones that seem relevant for a next release (cargo metadata and ensure docs).

Commit messages do not contain emojis, feel free to adapt them to the needs of this project. Also feel free to update the title of this PR to something more useful.