### PR TITLE
Allow encoding into chunks

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -296,7 +296,7 @@ mod tests {
         let mut encoder = ChunkedEncoder::new(FrameType::Diagnostic, DATA.as_bytes());
         let mut output = Vec::new();
         while !encoder.is_exhausted() {
-            let mut buf = [0, 0];
+            let mut buf = [0; N];
             let length = encoder.encode_chunk(&mut buf);
             output.extend_from_slice(&buf[..length]);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,7 @@ mod decoder;
 mod encode;
 mod framehandler;
 
+pub use encode::ChunkedEncoder;
 pub use encode::encode;
 #[cfg(feature = "std")]
 pub use encode::encode_buffered;


### PR DESCRIPTION
Currently, if I have a 1200 byte CoAP buffer in a constrained device and want to send that to a UART (which is maybe buffered to a few bytes), I need to allocate a 2404-ish byte output buffer.

This PR adds a struct that can deal out pieces of data in chunks down to 2 bytes; it is a heavy refactoring of what used to be encode (which itself is now just driving that encoder through a single step).

It's a heavy PR in terms of LoC (+167-22 for a net +145, although 48 thereof is just tests), but I think it is useful for embedded applications. On the history, feel free to peruse if you feel like digging into history, but due to PR-internal refactoring, this is best reviewed as a single large diff.