### PR TITLE
🐛: declare IP packet in decode() return value

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -182,7 +182,7 @@ impl Decoder {
                 (Ip, Constants::END) => {
                     self.state = Idle;
                     handler.end_frame(None);
-                    return Ok(DecodeStatus::FrameCompleteConfiguration);
+                    return Ok(DecodeStatus::FrameCompleteIp);
                 }
                 (Ip, _) => {
                     handler.write_byte(byte);


### PR DESCRIPTION
This went unnoticed because the type information is two places, and was not previously tested here.